### PR TITLE
Prevent git from reading /etc/gitconfig

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -306,6 +306,8 @@ apps:
             - removable-media
             - ssh-keys
             - mount-observe
+        environment:
+          GIT_CONFIG_NOSYSTEM: 1
 
     ssh-agent:
         command: usr/bin/ssh-agent -D -a $SSH_AUTH_SOCK


### PR DESCRIPTION
If `/etc/gitconfig` exists, `opengrok.update-source` will fail when trying to read it, so I've disabled checking the system-level config.